### PR TITLE
Include app CSS in Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: [
+                'resources/css/app.css',
                 'resources/css/filament.css',
                 'resources/js/app.js',
             ],


### PR DESCRIPTION
## Summary
- include `resources/css/app.css` in Vite inputs so application styles are built

## Testing
- `npm run build` (fails: Unable to resolve `@import "../../vendor/filament/filament/resources/css/theme.css"`)
- `composer test` (fails: missing `vendor/autoload.php`)


------
https://chatgpt.com/codex/tasks/task_e_68adff416bb483279b8fe126069a275d