### PR TITLE
Include app CSS and fix Filament theme import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,14 @@
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
+            "@php artisan filament:assets --ansi"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-install-cmd": [
+            "@php artisan filament:assets --ansi"
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-@import '../../vendor/filament/filament/resources/css/theme.css';
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';

--- a/resources/css/filament.css
+++ b/resources/css/filament.css
@@ -1,4 +1,4 @@
-@import "../../vendor/filament/filament/resources/css/theme.css";
+@import "/vendor/filament/filament/resources/css/theme.css";
 
 /* Медицинская цветовая палитра */
 :root {

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: [
+                'resources/css/app.css',
                 'resources/css/filament.css',
                 'resources/js/app.js',
             ],


### PR DESCRIPTION
## Summary
- include `resources/css/app.css` in Vite inputs so application styles are built
- fix `resources/css/filament.css` to import Filament theme using `/vendor` alias
- ensure Filament assets are published and drop duplicate theme import

## Testing
- `npm run build` (fails: ENOENT no such file or directory 'vendor/filament/filament/resources/css/theme.css')
- `composer test` (fails: missing `vendor/autoload.php`)


------
https://chatgpt.com/codex/tasks/task_e_68adff416bb483279b8fe126069a275d